### PR TITLE
shorter token format; only base64 encode the hmac

### DIFF
--- a/authnid/token.py
+++ b/authnid/token.py
@@ -2,7 +2,8 @@ import time
 import hashlib
 import hmac
 import base64
-import binascii
+
+JOIN_CHAR = '.'
 
 class TokenManager():
     def __init__(self, secret):
@@ -10,18 +11,15 @@ class TokenManager():
 
     # stub user ID until we implement it
     def token(self, user_id=10000):
-        payload = f'{user_id}:{self._timestamp()}'
+        payload = f'{user_id}{JOIN_CHAR}{self._timestamp()}'
         return self._encode(payload)
 
     def validate(self, token):
-        try:
-            decoded = base64.urlsafe_b64decode(token).decode()
-            parts = decoded.split(':')
-            recoded = self._encode(':'.join(parts[1:]))
-            y = self._check_timestamp(parts[2]) and hmac.compare_digest(token, recoded)
-            return y
-        except binascii.Error:
+        parts = token.split(JOIN_CHAR)
+        if len(parts) != 3:
             return False
+        recoded = self._encode(JOIN_CHAR.join(parts[1:]))
+        return self._check_timestamp(parts[2]) and hmac.compare_digest(token, recoded)
 
     def _check_timestamp(self, timestamp):
         return abs(self._timestamp() - int(timestamp)) <= 2
@@ -32,5 +30,5 @@ class TokenManager():
     def _encode(self, payload):
         payload_bytes = payload.encode()
         hashed = hmac.new(self._secret, payload_bytes, hashlib.sha256)
-        hexed = binascii.hexlify(hashed.digest())
-        return base64.urlsafe_b64encode(hexed + b':' + payload_bytes).decode()
+        url_digest = base64.urlsafe_b64encode(hashed.digest()).decode()
+        return url_digest + JOIN_CHAR + payload

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -3,7 +3,7 @@ import re
 import base64
 
 def is_token(token):
-    return re.match('\A[\w\-=]+\Z', token)
+    return re.match('\A[\w\-=]+\.[\w\-=]+\.[\w\-=]+\Z', token)
 
 def relative_dir(path):
     return f'{os.getcwd()}/{path}'


### PR DESCRIPTION
@briandds suggested that we don't need to base64 encode the whole token, since the timestamp and UUID will be URL safe anyway. This revises the token format slightly to only apply URL-safe base64 encoding to the binary HMAC value. 