### PR TITLE
server script should not exit

### DIFF
--- a/script/up
+++ b/script/up
@@ -5,4 +5,4 @@
 set -e
 cd "$(dirname "$0")/.."
 
-docker-compose up -d
+docker-compose up


### PR DESCRIPTION
Quick fix. In order to use something like foreman to manage our server processes in atat-stack, none of the server scripts can exit.