### PR TITLE
server script should not exit by default

### DIFF
--- a/script/server
+++ b/script/server
@@ -10,4 +10,4 @@ cd "$(dirname "$0")/.."
 script/update
 
 # start the docker container
-script/up
+script/up -d

--- a/script/server
+++ b/script/server
@@ -10,4 +10,4 @@ cd "$(dirname "$0")/.."
 script/update
 
 # start the docker container
-script/up -d
+script/up

--- a/script/test
+++ b/script/test
@@ -9,7 +9,7 @@ cd "$(dirname "$0")/.."
 # ensure everything in the app is up to date.
 script/update
 # bring up the application stack
-script/up
+script/up -d
 
 #TODO wait for application to become responsive
 

--- a/script/up
+++ b/script/up
@@ -5,4 +5,4 @@
 set -e
 cd "$(dirname "$0")/.."
 
-docker-compose up -d
+docker-compose up $*


### PR DESCRIPTION
Github wouldn't let me reopen the other PR because I force-pushed to it. Anyway...

In order to use something like foreman to manage our server processes in atat-stack, none of the server scripts can exit. Now `script/up` takes arguments and passes them to `docker-compose up`, so the test script and others can tell it to run in the background, but it runs in the foreground by default.