### PR TITLE
general README updates, as well intermediate DoD cert directions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Back end local development
 
-To build, run `script/sertup`.  `script/server` starts the stack with Docker Compose:
+To build, run `script/setup`.  `script/server` starts the stack with Docker Compose:
 
 * DNS will handle redirecting `dev.cac.atat.codes` to localhost. So, in your browser, go to: http://dev.cac.atat.codes.
 

--- a/README.md
+++ b/README.md
@@ -4,37 +4,44 @@
 
 ## Back end local development
 
-* Start the stack with Docker Compose:
-
-```bash
-docker-compose up -d
-```
+To build, run `script/sertup`.  `script/server` starts the stack with Docker Compose:
 
 * DNS will handle redirecting `dev.cac.atat.codes` to localhost. So, in your browser, go to: http://dev.cac.atat.codes.
 
-The `docker-compose.override.yml` file for local development has a host volume with your app files inside the container for rapid iteration. So you can update your code and it will be the same code (updated) inside the container. You just have to restart the server, but you don't need to rebuild the image to test a change. Make sure you use this only for local development. Your final production images should be built with the latest version of your code and do not depend on host volumes mounted.
+The `docker-compose.override.yml` file for local development has a host volume with your app files inside the container for rapid iteration. So you can update your code and it will be the same code (updated) inside the container. You have to restart the server, but you don't need to rebuild the image to test a change. Make sure you use this only for local development. Your final production images should be built with the latest version of your code and do not depend on host volumes mounted.
 
 ### Back end tests
 
 To test the back end run:
 
 ```bash
-# Start and build the testing stack
-docker-compose up -d --build
-sleep 20; # Give some time for the DB and prestart script to finish
-# Run the REST tests
-docker-compose exec -T backend-tests pytest
-# Stop and eliminate the testing stack
-docker-compose down -v --remove-orphans
+script/test
 ```
 
-**NOTE:** For the tests to run, they need to know the location of:
+The tests run with Pytest. Modify and add tests to `./tests/`.
 
-- the server's certificate authority (`ssl/certificate-authority/ca.crt`), set in the testing docker container with teh `REQUESTS_CA_BUNDLE` env variable
-- the client public cert and private key, both in `ssl/client-certs/`
-
-The tests run with Pytest, modify and add tests to `./tests/`.
-
-### SSL Certificates
+### SSL Certificates for Testing
 
 The `ssl` directory contains example certs for configuring the regular server SSL, client authentication, and the client certificates currently written to the sample PIVKey. It also contains a script, `make-certs.sh`, which can be used to write a new certificate authority and sign a CSR for the server SSL. The script writes the CSR to list multiple valid hosts (`subjectAltName`) so that the final cert can work across environments (like docker, for instance, where it's host name is "backend").
+
+note: add info about the intermediate CAs
+
+### Intermediate CAs
+
+We are using `pyopenssl` for CRL checks. Currently, this requires that the intermediate CAs for any client CAs be in the CA chain. If you have a DDS CAC card and want to test for local development, you need to add the right intermediate CA before spinning up the server. To do this:
+
+- Try a different CAC-enabled site and pay attention the CA listed next to the cert you use in the browser certificate prompt (for instance, if you log in with an email cert and it says "CA-43" next to your cert, you need "DOD EMAIL CA-43.cer").
+- Download the corresponding intermediate cert here: https://militarycac.com/maccerts/
+- Convert the cert from DER to PEM format:
+
+```
+openssl crl -inform DER -outform PEM -in [path to the downloaded cert] -out cert-output.pem
+```
+
+- Then you need to append it to the CA bundle:
+
+```
+cat cert-output.pem >> ssl/server-certs/ca-chain.pem
+```
+
+- Build and start the server as outlined above. Now your intermediate cert is part of the CA chain that both NGINX and the CRL validator use.

--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@
 
 To build, run `script/setup`.  `script/server` starts the stack with Docker Compose:
 
-* DNS will handle redirecting `dev.cac.atat.codes` to localhost. So, in your browser, go to: http://dev.cac.atat.codes.
-
 The `docker-compose.override.yml` file for local development has a host volume with your app files inside the container for rapid iteration. So you can update your code and it will be the same code (updated) inside the container. You have to restart the server, but you don't need to rebuild the image to test a change. Make sure you use this only for local development. Your final production images should be built with the latest version of your code and do not depend on host volumes mounted.
 
 ### Back end tests

--- a/README.md
+++ b/README.md
@@ -24,8 +24,6 @@ The tests run with Pytest. Modify and add tests to `./tests/`.
 
 The `ssl` directory contains example certs for configuring the regular server SSL, client authentication, and the client certificates currently written to the sample PIVKey. It also contains a script, `make-certs.sh`, which can be used to write a new certificate authority and sign a CSR for the server SSL. The script writes the CSR to list multiple valid hosts (`subjectAltName`) so that the final cert can work across environments (like docker, for instance, where it's host name is "backend").
 
-note: add info about the intermediate CAs
-
 ### Intermediate CAs
 
 We are using `pyopenssl` for CRL checks. Currently, this requires that the intermediate CAs for any client CAs be in the CA chain. If you have a DDS CAC card and want to test for local development, you need to add the right intermediate CA before spinning up the server. To do this:


### PR DESCRIPTION
This updates the README to refer to the scripts-to-rule-them-all and adds directions for adding DoD intermediate certs to the CA bundle. This will change pending resolution of [this](https://www.pivotaltracker.com/n/projects/2160940/stories/158497124) Pivotal discussion.