### PR TITLE
better logging in CRL sync and more careful replacement of CRL dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,5 @@ __pycache__
 .pytest_cache/
 *.pyc
 *.cfg
-/crl/
+/crl*/
 ALLCRLZIP.zip

--- a/authnid/crl/util.py
+++ b/authnid/crl/util.py
@@ -59,13 +59,14 @@ if __name__ == "__main__":
     import datetime
     import logging
 
-    def configured_logger():
-        logging.basicConfig(
-            level=logging.INFO, format="[%(asctime)s]:%(levelname)s: %(message)s"
-        )
-        return logging.getLogger()
-
-    logger = configured_logger()
+    logging.basicConfig(
+        level=logging.INFO, format="[%(asctime)s]:%(levelname)s: %(message)s"
+    )
+    logger = logging.getLogger()
     logger.info("Updating CRLs")
-    refresh_crls(sys.argv[1], logger=logger)
+    try:
+        refresh_crls(sys.argv[1], logger=logger)
+    except Exception as err:
+        logger.exception("Fatal error encountered, stopping")
+        sys.exit(1)
     logger.info("Finished updating CRLs")

--- a/authnid/crl/util.py
+++ b/authnid/crl/util.py
@@ -1,7 +1,6 @@
 import requests
 import re
 import os
-import sys
 from html.parser import HTMLParser
 
 _DISA_CRLS = "https://iasecontent.disa.mil/pki-pke/data/crls/dod_crldps.htm"
@@ -30,25 +29,43 @@ def crl_list_from_disa_html(html):
     return parser.crl_list
 
 
-def write_crls(out_dir, crl_list):
-    for crl_location in crl_list:
-        name = re.split("/", crl_location)[-1]
-        crl = os.path.join(out_dir, name)
-        try:
-            with requests.get(crl_location, stream=True) as r:
-                with open(crl, "wb") as crl_file:
-                    for chunk in r.iter_content(chunk_size=1024):
-                        if chunk:
-                            crl_file.write(chunk)
-        except requests.exceptions.ChunkedEncodingError:
-            print("Error downloading {}, continuing anyway".format(crl_location))
+def write_crl(out_dir, crl_location):
+    name = re.split("/", crl_location)[-1]
+    crl = os.path.join(out_dir, name)
+    with requests.get(crl_location, stream=True) as r:
+        with open(crl, "wb") as crl_file:
+            for chunk in r.iter_content(chunk_size=1024):
+                if chunk:
+                    crl_file.write(chunk)
 
 
-def refresh_crls(out_dir):
+def refresh_crls(out_dir, logger=None):
     disa_html = fetch_disa()
     crl_list = crl_list_from_disa_html(disa_html)
-    write_crls(out_dir, crl_list)
+    for crl_location in crl_list:
+        if logger:
+            logger.info("updating CRL from {}".format(crl_location))
+        try:
+            write_crl(out_dir, crl_location)
+        except requests.exceptions.ChunkedEncodingError:
+            if logger:
+                logger.error(
+                    "Error downloading {}, continuing anyway".format(crl_location)
+                )
 
 
 if __name__ == "__main__":
-    refresh_crls(sys.argv[1])
+    import sys
+    import datetime
+    import logging
+
+    def configured_logger():
+        logging.basicConfig(
+            level=logging.INFO, format="[%(asctime)s]:%(levelname)s: %(message)s"
+        )
+        return logging.getLogger()
+
+    logger = configured_logger()
+    logger.info("Updating CRLs")
+    refresh_crls(sys.argv[1], logger=logger)
+    logger.info("Finished updating CRLs")

--- a/script/sync-crls
+++ b/script/sync-crls
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 # script/sync-crls: update the DOD CRLs and place them where authnid expects them
+set -e
 
 mkdir -p crl-tmp
 pipenv run python ./authnid/crl/util.py crl-tmp

--- a/script/sync-crls
+++ b/script/sync-crls
@@ -2,10 +2,11 @@
 
 # script/sync-crls: update the DOD CRLs and place them where authnid expects them
 
-rm -rf crl/ || true
+mkdir -p crl-tmp
+pipenv run python ./authnid/crl/util.py crl-tmp
 mkdir -p crl
-echo "Updating local CRLs..."
-pipenv run python ./authnid/crl/util.py crl
+rsync -rq crl-tmp/. crl/.
+rm -rf crl-tmp
 
 if [[ $FLASK_ENV != "production" ]]; then
   # place our test CRL there

--- a/script/sync-crls
+++ b/script/sync-crls
@@ -2,6 +2,7 @@
 
 # script/sync-crls: update the DOD CRLs and place them where authnid expects them
 set -e
+cd "$(dirname "$0")/.."
 
 mkdir -p crl-tmp
 pipenv run python ./authnid/crl/util.py crl-tmp

--- a/test/test_crl.py
+++ b/test/test_crl.py
@@ -78,9 +78,9 @@ class MockStreamingResponse():
     def __exit__(self, *args):
         pass
 
-def test_write_crls(tmpdir, monkeypatch):
+def test_write_crl(tmpdir, monkeypatch):
     monkeypatch.setattr('requests.get', lambda u, **kwargs: MockStreamingResponse([b'it worked']))
-    crl_list = ['crl_1']
-    util.write_crls(tmpdir, crl_list)
-    assert [p.basename for p in tmpdir.listdir()] == crl_list
+    crl = 'crl_1'
+    util.write_crl(tmpdir, crl)
+    assert [p.basename for p in tmpdir.listdir()] == [crl]
     assert [p.read() for p in tmpdir.listdir()] == ['it worked']


### PR DESCRIPTION
I realized that the original `sync-crls` script deletes the crl directory when it starts, meaning that it might not be there if the app tries to rebuild its CRL cache while the CRLs are being updated. This syncs to a temp dir and then rsyncs the new copies and adds better logging for the sync operation.