### PR TITLE
separate config for ci

### DIFF
--- a/config/ci.ini
+++ b/config/ci.ini
@@ -1,0 +1,2 @@
+[default]
+DATABASE_URI = postgres://atat:password@db/authnid


### PR DESCRIPTION
This provides additional config CI uses the docker postgres instance in atat-stack. (The `FLASK_ENV` is set to `ci` in atat-stack CI.)